### PR TITLE
[Game engine] Game state

### DIFF
--- a/rts-core/src/components/building.rs
+++ b/rts-core/src/components/building.rs
@@ -1,7 +1,9 @@
 use crate::components::unit_factory::UnitFactory;
+use crate::components::turn_strategy::TurnStrategy;
 use crate::entity::player::Player;
 use crate::entity::unit::{Unit, UnitType};
 use crate::exceptions::RtsException;
+
 
 /// Produces units and get money from players
 pub struct Barrack {
@@ -20,7 +22,7 @@ impl Default for Barrack {
 const NEW_MONEY_BATCH: i32 = 100;
 
 impl Bank {
-    pub fn give_money(player: &mut Player) -> Result<(), RtsException> {
+    pub fn give_money(player: &mut Player<TurnStrategy>) -> Result<(), RtsException> {
         if let Some(_money) = player.update_money(NEW_MONEY_BATCH) {
             Ok(())
         } else {
@@ -38,7 +40,7 @@ impl Barrack {
         }
     }
 
-    pub fn buy_unit(&self, unit_type: UnitType, player: &mut Player) -> Result<Unit, RtsException> {
+    pub fn buy_unit(&self, unit_type: UnitType, player: &mut Player<TurnStrategy>) -> Result<Unit, RtsException> {
         if self.retrieve_money(&unit_type, player) {
             Ok(self.unit_factory.build_unit(unit_type))?
         } else {
@@ -49,7 +51,7 @@ impl Barrack {
         }
     }
 
-    fn retrieve_money(&self, unit_type: &UnitType, player: &mut Player) -> bool {
+    fn retrieve_money(&self, unit_type: &UnitType, player: &mut Player<TurnStrategy>) -> bool {
         player.update_money(-unit_type.get_cost() as i32).is_some()
     }
 }
@@ -59,10 +61,11 @@ mod test_building {
     use super::Barrack;
     use crate::entity::player::Player;
     use crate::entity::unit::UnitType;
+    use crate::components::turn_strategy::TurnStrategy;
 
     #[test]
     pub fn should_buy_unit() {
-        let mut player = Player::new(String::from("Tigran"));
+        let mut player = Player::new(String::from("Tigran"), TurnStrategy::AI);
         player.update_money(100);
         let barrack = Barrack::default();
 

--- a/rts-core/src/components/building.rs
+++ b/rts-core/src/components/building.rs
@@ -1,11 +1,10 @@
 use crate::components::unit_factory::UnitFactory;
-use crate::components::turn_strategy::TurnStrategy;
 use crate::entity::player::Player;
+use crate::entity::player::TurnStrategyRequester;
 use crate::entity::unit::{Unit, UnitType};
 use crate::exceptions::RtsException;
 
-
-/// Produces units and get money from players
+/// Produce units and take money from players
 pub struct Barrack {
     unit_factory: UnitFactory,
 }
@@ -22,7 +21,9 @@ impl Default for Barrack {
 const NEW_MONEY_BATCH: i32 = 100;
 
 impl Bank {
-    pub fn give_money(player: &mut Player<TurnStrategy>) -> Result<(), RtsException> {
+    pub fn give_money<T: TurnStrategyRequester>(
+        player: &mut Player<T>,
+    ) -> Result<(), RtsException> {
         if let Some(_money) = player.update_money(NEW_MONEY_BATCH) {
             Ok(())
         } else {
@@ -40,7 +41,11 @@ impl Barrack {
         }
     }
 
-    pub fn buy_unit(&self, unit_type: UnitType, player: &mut Player<TurnStrategy>) -> Result<Unit, RtsException> {
+    pub fn buy_unit<T: TurnStrategyRequester>(
+        &self,
+        unit_type: UnitType,
+        player: &mut Player<T>,
+    ) -> Result<Unit, RtsException> {
         if self.retrieve_money(&unit_type, player) {
             Ok(self.unit_factory.build_unit(unit_type))?
         } else {
@@ -51,7 +56,11 @@ impl Barrack {
         }
     }
 
-    fn retrieve_money(&self, unit_type: &UnitType, player: &mut Player<TurnStrategy>) -> bool {
+    fn retrieve_money<T: TurnStrategyRequester>(
+        &self,
+        unit_type: &UnitType,
+        player: &mut Player<T>,
+    ) -> bool {
         player.update_money(-unit_type.get_cost() as i32).is_some()
     }
 }
@@ -59,9 +68,9 @@ impl Barrack {
 #[cfg(test)]
 mod test_building {
     use super::Barrack;
+    use crate::components::turn_strategy::TurnStrategy;
     use crate::entity::player::Player;
     use crate::entity::unit::UnitType;
-    use crate::components::turn_strategy::TurnStrategy;
 
     #[test]
     pub fn should_buy_unit() {

--- a/rts-core/src/components/game.rs
+++ b/rts-core/src/components/game.rs
@@ -8,7 +8,7 @@ use crate::components::displayer::{ConsoleDisplayer, Displayer};
 use crate::components::play_ground::{Coordinate, Identifier, PlayGround, PlayGroundObserver};
 use crate::components::turn_strategy::TurnStrategy;
 use crate::entity::game_actions::{Action, MoveState};
-use crate::entity::player::{Player, TurnStrategyRequester};
+use crate::entity::player::Player;
 use crate::entity::unit::{Unit, UnitType};
 use crate::exceptions::RtsException;
 
@@ -82,8 +82,8 @@ where
 
     fn play_with_all_players(&self) -> Result<(), RtsException> {
         for (i, player) in self.players.iter().enumerate() {
-            let p = Rc::clone(&player);
-            let action = p.borrow().request()?;
+            let player_ptr = Rc::clone(player);
+            let action = player_ptr.borrow().request()?;
             self.play(i, action)?;
         }
 
@@ -207,7 +207,6 @@ mod tests_play_ground {
     use crate::entity::unit::UnitType;
 
     use super::GameStateObserver;
-
 
     struct TestClientGameState();
     impl GameStateObserver for TestClientGameState {

--- a/rts-core/src/components/mod.rs
+++ b/rts-core/src/components/mod.rs
@@ -3,4 +3,5 @@ pub mod unit_factory;
 pub mod game;
 pub mod play_ground;
 pub mod displayer;
+pub mod turn_strategy;
 

--- a/rts-core/src/components/turn_strategy.rs
+++ b/rts-core/src/components/turn_strategy.rs
@@ -1,0 +1,15 @@
+use crate::entity::game_actions::Action;
+use crate::entity::player::TurnStrategyRequester;
+use crate::exceptions::RtsException;
+
+pub enum TurnStrategy {
+    AI,
+}
+
+impl TurnStrategyRequester for TurnStrategy {
+    fn request(&self) -> Result<Action, RtsException> {
+        match &self {
+            TurnStrategy::AI => todo!(),
+        }
+    }
+}

--- a/rts-core/src/entity/player.rs
+++ b/rts-core/src/entity/player.rs
@@ -1,28 +1,35 @@
 use std::fmt::Display;
 
-use super::game_actions::Action;
+use crate::exceptions::RtsException;
+use crate::entity::game_actions::Action;
 
-pub trait TurnStrategy {
-    fn ask(&self) -> Action;
+pub trait TurnStrategyRequester {
+    fn request(&self) -> Result<Action, RtsException>;
 }
 
-pub struct Player {
+pub struct Player<TurnStrategy>
+where
+    TurnStrategy: TurnStrategyRequester,
+{
     name: String,
     wallet: Wallet,
+    turn_strategy_requester: TurnStrategy,
 }
 
-impl TurnStrategy for Player {
-    fn ask(&self) -> Action {
-        todo!() 
-    }
-}
-
-impl Player {
-    pub fn new(name: String) -> Self {
+impl<TurnStrategy> Player<TurnStrategy>
+where
+    TurnStrategy: TurnStrategyRequester,
+{
+    pub fn new(name: String, turn_strategy_requester: TurnStrategy) -> Self {
         Player {
             name,
             wallet: Wallet::new(),
+            turn_strategy_requester,
         }
+    }
+
+    pub fn request(&self) -> Result<Action, RtsException> {
+        self.turn_strategy_requester.request()
     }
 
     pub fn get_name(&self) -> &str {
@@ -53,7 +60,10 @@ impl Wallet {
     }
 }
 
-impl Display for Player {
+impl<TurnStrategy> Display for Player<TurnStrategy>
+where
+    TurnStrategy: TurnStrategyRequester,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "name: {} wallet: {}", self.name, self.wallet)
     }
@@ -68,18 +78,29 @@ impl Display for Wallet {
 #[cfg(test)]
 mod test_wallet {
 
+    use crate::entity::game_actions::Action;
+    use crate::exceptions::RtsException;
+
     use super::Player;
+    use super::TurnStrategyRequester;
+
+    pub struct TestTurnStrategyRequester;
+    impl TurnStrategyRequester for TestTurnStrategyRequester {
+        fn request(&self) -> Result<Action, RtsException> {
+            Ok(Action::GiveMoneyBatch)
+        }
+    }
 
     #[test]
     pub fn should_earn_money() {
-        let mut player = Player::new("Tigran".to_string());
+        let mut player = Player::new("Tigran".to_string(), TestTurnStrategyRequester);
         player.update_money(10);
         assert_eq!(&10, player.get_money())
     }
 
     #[test]
     pub fn should_loose_money() {
-        let mut player = Player::new("Tigran".to_string());
+        let mut player = Player::new("Tigran".to_string(), TestTurnStrategyRequester);
         player.update_money(10);
         player.update_money(-8);
         assert_eq!(&2, player.get_money())

--- a/rts-core/src/entity/player.rs
+++ b/rts-core/src/entity/player.rs
@@ -1,17 +1,19 @@
 use std::fmt::Display;
 
+use super::game_actions::Action;
+
+pub trait TurnStrategy {
+    fn ask(&self) -> Action;
+}
+
 pub struct Player {
     name: String,
     wallet: Wallet,
 }
 
-struct Wallet {
-    money: i32,
-}
-
-impl Wallet {
-    fn new() -> Self {
-        Wallet { money: 0 }
+impl TurnStrategy for Player {
+    fn ask(&self) -> Action {
+        todo!() 
     }
 }
 
@@ -38,6 +40,16 @@ impl Player {
         } else {
             None
         }
+    }
+}
+
+struct Wallet {
+    money: i32,
+}
+
+impl Wallet {
+    fn new() -> Self {
+        Wallet { money: 0 }
     }
 }
 

--- a/rts-server/src/main.rs
+++ b/rts-server/src/main.rs
@@ -279,40 +279,6 @@ async fn leaderboard(state: web::Data<AppState<'_>>) -> impl Responder {
     HttpResponse::Ok().body("Leaderboard")
 }
 
-async fn start(game: &Game) {
-    println!("Launch game");
-    match game.start().await {
-        Ok(_) => println!("GS"),
-        Err(e) => println!("{}", e),
-    }
-}
-
-async fn play(game: &Game, action: Action) {
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    let action_name = action.get_name();
-    match game.play_with_async(0, action).await {
-        Ok(_) => println!("Play {}", action_name),
-        Err(e) => println!("{}", e),
-    }
-
-    game.console_display().unwrap();
-}
-
-async fn run_game() {
-    let p1 = Player::new("Tigran".to_string());
-    let p2 = Player::new("Emma".to_string());
-    let game = Game::new(vec![p1, p2]);
-
-    game.console_display().unwrap();
-
-    let t1 = start(&game);
-
-    let turn = play(&game, Action::BuyUnit(UnitType::Classic)).await;
-    tokio::select! {
-        _ = t1 => println!("Game started"),
-    };
-}
-
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     println!("Starting the rts web server");


### PR DESCRIPTION
- [x] Remove `async`, `Arc`, `Mutex` from `Game`
- [x] Add observer logic for clients to hookup and get informed -> `GameStateObserver`
- [x] Players should be asked on their actions -> `TurnStrategy`
- [ ] Plug enum `Action` with Actix `Actors` to handle async actions on `Game`